### PR TITLE
Parse TransmitterPdu modulation parameters and variable transmitter parameters

### DIFF
--- a/opendis/bitfield.py
+++ b/opendis/bitfield.py
@@ -1,0 +1,100 @@
+"""Bitfield type factory and related utilities.
+
+This module provides a factory function to create ctypes.Structure subclasses
+representing bitfields as defined in the DIS standard. These bitfields are used
+in various DIS records to pack multiple non-octet-aligned fields into a compact
+binary representation.
+"""
+
+from ctypes import (
+    _SimpleCData,
+    BigEndianStructure,
+    c_uint8,
+    c_uint16,
+    c_uint32,
+    sizeof,
+)
+from typing import Literal, Sequence
+
+from opendis.stream import DataInputStream, DataOutputStream
+
+# Type definitions for bitfield field descriptors
+CTypeFieldDescription = tuple[str, type[_SimpleCData], int]
+DisFieldDescription = tuple[str, "DisFieldType", int]
+
+# Field type constants simplify the construction of bitfields
+# which would otherwise require manually specifying ctypes types.
+# The currently implemented bitfields only use integers, but DIS7
+# mentions CHAR types which may be needed in future.
+DisFieldType = Literal["INTEGER"]
+INTEGER = "INTEGER"
+
+
+def _field(name: str,
+          ftype: DisFieldType,
+          bits: int) -> CTypeFieldDescription:
+    """Helper function to create the field description tuple used by ctypes."""
+    match (ftype, bits):
+        case (INTEGER, b) if 0 < b <= 8:
+            return (name, c_uint8, bits)
+        case (INTEGER, b) if 8 < b <= 16:
+            return (name, c_uint16, bits)
+        case (INTEGER, b) if 16 < b <= 32:
+            return (name, c_uint32, bits)
+        case _:
+            raise ValueError(f"Unrecognized (ftype, bits): {ftype}, {bits}")
+
+
+def bitfield(name: str,
+              fields: Sequence[DisFieldDescription]):
+    """Factory function for bitfield structs, which are subclasses of
+    ctypes.Structure.
+    These are used in records that require them to unpack non-octet-sized fields.
+
+    Args:
+        name: Name of the bitfield struct.
+        bytesize: Size of the bitfield in bytes.
+        fields: Sequence of tuples defining fields of the bitfield, in the form
+            (field_name, "INTEGER", field_size_in_bits).
+    """
+    # Argument validation
+    struct_fields = []
+    bitsize = 0
+    for name, ftype, bits in fields:
+        if ftype not in (INTEGER,):
+            raise ValueError(f"Unsupported field type: {ftype}")
+        if not isinstance(bits, int):
+            raise ValueError(f"Field size must be int: {bits!r}")
+        if bits <= 0 or bits > 32:
+            raise ValueError(f"Field size must be between 1 and 32: got {bits}")
+        bitsize += bits
+        struct_fields.append(_field(name, ftype, bits))
+
+    if bitsize == 0:
+        raise ValueError(f"Bitfield size cannot be zero")
+    elif bitsize % 8 != 0:
+        raise ValueError(f"Bitfield size must be multiple of 8, got {bitsize}")
+    bytesize = bitsize // 8
+
+    # Create the struct class
+    class Bitfield(BigEndianStructure):
+        _fields_ = struct_fields
+
+        @staticmethod
+        def marshalledSize() -> int:
+            return bytesize
+
+        def serialize(self, outputStream: DataOutputStream) -> None:
+            outputStream.write_bytes(bytes(self))
+
+        @classmethod
+        def parse(cls, inputStream: DataInputStream) -> "Bitfield":
+            return cls.from_buffer_copy(inputStream.read_bytes(bytesize))
+
+    # Sanity check: ensure the struct size matches expected size
+    assert sizeof(Bitfield) == bytesize, \
+        f"Bitfield size mismatch: expected {bytesize}, got {sizeof(Bitfield)}"
+
+    # Assign the class name
+    Bitfield.__name__ = name
+    return Bitfield

--- a/opendis/dis7.py
+++ b/opendis/dis7.py
@@ -5470,6 +5470,16 @@ class TransmitterPdu(RadioCommunicationsFamilyPdu):
             self.antennaPattern = None
         
         ## TODO: Variable Transmitter Parameters
+        for _ in range(0, variableTransmitterParameterCount):
+            recordType = inputStream.read_uint32()
+            if recordType == 3000:  # High Fidelity HAVE QUICK/SATURN Radio
+                vtp = HighFidelityHAVEQUICKRadio()
+                vtp.parse(inputStream)
+            else:  # Unknown VTP record type
+                vtp = UnknownVariableTransmitterParameters()
+                vtp.recordType = recordType
+                vtp.parse(inputStream)
+            self.variableTransmitterParameters.append(vtp)
 
 
 class ElectromagneticEmissionsPdu(DistributedEmissionsFamilyPdu):

--- a/opendis/dis7.py
+++ b/opendis/dis7.py
@@ -5436,8 +5436,21 @@ class TransmitterPdu(RadioCommunicationsFamilyPdu):
 
         ## Modulation Parameters
         if modulationParametersLength > 0:
-            radio = UnknownRadio()
-            radio.parse(inputStream, bytelength=modulationParametersLength)
+            if self.modulationType.radioSystem == 1:  # Generic | Simple Intercom
+                if self.modulationType.majorModulation == 0:
+                    radio = SimpleIntercomRadio()
+                else:
+                    radio = GenericRadio()
+                radio.parse(inputStream)
+            elif self.modulationType.radioSystem in (2, 3, 4):  # HAVE QUICK I | II | HAVE QUICK IIA
+                radio = BasicHaveQuickMP()
+                radio.parse(inputStream)
+            elif self.modulationType.radioSystem == 6:  # CCTT SINCGARS
+                radio = CCTTSincgarsMP()
+                radio.parse(inputStream)
+            else:  # Other | Unknown
+                radio = UnknownRadio()
+                radio.parse(inputStream, bytelength=modulationParametersLength)
             self.modulationParameters = radio
         else:
             self.modulationParameters = None

--- a/opendis/dis7.py
+++ b/opendis/dis7.py
@@ -10,6 +10,8 @@ from .record import (
     ModulationParametersRecord,
     UnknownRadio,
     UnknownAntennaPattern,
+    EulerAngles,
+    BeamAntennaPattern,
 )
 from .stream import DataInputStream, DataOutputStream
 from .types import (
@@ -678,34 +680,6 @@ class NamedLocationIdentification:
         self.stationNumber = inputStream.read_unsigned_short()
 
 
-class EulerAngles:
-    """Section 6.2.33
-
-    Three floating point values representing an orientation, psi, theta,
-    and phi, aka the euler angles, in radians.
-    """
-
-    def __init__(self,
-                 psi: float32 = 0.0,
-                 theta: float32 = 0.0,
-                 phi: float32 = 0.0):  # in radians
-        self.psi = psi
-        self.theta = theta
-        self.phi = phi
-
-    def serialize(self, outputStream):
-        """serialize the class"""
-        outputStream.write_float(self.psi)
-        outputStream.write_float(self.theta)
-        outputStream.write_float(self.phi)
-
-    def parse(self, inputStream):
-        """Parse a message. This may recursively call embedded objects."""
-        self.psi = inputStream.read_float()
-        self.theta = inputStream.read_float()
-        self.phi = inputStream.read_float()
-
-
 class DirectedEnergyPrecisionAimpoint:
     """Section 6.2.20.3
 
@@ -841,63 +815,6 @@ class OwnershipStatus:
         self.entityId.parse(inputStream)
         self.ownershipStatus = inputStream.read_unsigned_byte()
         self.padding = inputStream.read_unsigned_byte()
-
-
-class BeamAntennaPattern:
-    """Section 6.2.9.2
-    
-    Used when the antenna pattern type field has a value of 1. Specifies the
-    direction, pattern, and polarization of radiation from an antenna.
-    """
-
-    def __init__(self,
-                 beamDirection: "EulerAngles | None" = None,
-                 azimuthBeamwidth: float32 = 0.0,  # in radians
-                 elevationBeamwidth: float32 = 0.0,  # in radians
-                 referenceSystem: enum8 = 0,  # [UID 168]
-                 ez: float32 = 0.0,
-                 ex: float32 = 0.0,
-                 phase: float32 = 0.0):  # in radians
-        self.beamDirection = EulerAngles()
-        """The rotation that transforms the reference coordinate sytem into the beam coordinate system. Either world coordinates or entity coordinates may be used as the reference coordinate system, as specified by the reference system field of the antenna pattern record."""
-        self.azimuthBeamwidth = azimuthBeamwidth
-        self.elevationBeamwidth = elevationBeamwidth
-        self.referenceSystem = referenceSystem
-        self.padding1: uint8 = 0
-        self.padding2: uint16 = 0
-        self.ez = ez
-        """This field shall specify the magnitude of the Z-component (in beam coordinates) of the Electrical field at some arbitrary single point in the main beam and in the far field of the antenna."""
-        self.ex = ex
-        """This field shall specify the magnitude of the X-component (in beam coordinates) of the Electrical field at some arbitrary single point in the main beam and in the far field of the antenna."""
-        self.phase = phase
-        """This field shall specify the phase angle between EZ and EX in radians. If fully omni-directional antenna is modeled using beam pattern type one, the omni-directional antenna shall be represented by beam direction Euler angles psi, theta, and phi of zero, an azimuth beamwidth of 2PI, and an elevation beamwidth of PI"""
-        self.padding3: uint32 = 0
-
-    def serialize(self, outputStream):
-        """serialize the class"""
-        self.beamDirection.serialize(outputStream)
-        outputStream.write_float(self.azimuthBeamwidth)
-        outputStream.write_float(self.elevationBeamwidth)
-        outputStream.write_unsigned_byte(self.referenceSystem)
-        outputStream.write_unsigned_byte(self.padding1)
-        outputStream.write_unsigned_short(self.padding2)
-        outputStream.write_float(self.ez)
-        outputStream.write_float(self.ex)
-        outputStream.write_float(self.phase)
-        outputStream.write_unsigned_int(self.padding3)
-
-    def parse(self, inputStream):
-        """Parse a message. This may recursively call embedded objects."""
-        self.beamDirection.parse(inputStream)
-        self.azimuthBeamwidth = inputStream.read_float()
-        self.elevationBeamwidth = inputStream.read_float()
-        self.referenceSystem = inputStream.read_unsigned_byte()
-        self.padding1 = inputStream.read_unsigned_byte()
-        self.padding2 = inputStream.read_unsigned_short()
-        self.ez = inputStream.read_float()
-        self.ex = inputStream.read_float()
-        self.phase = inputStream.read_float()
-        self.padding3 = inputStream.read_unsigned_int()
 
 
 class AttachedParts:

--- a/opendis/dis7.py
+++ b/opendis/dis7.py
@@ -12,6 +12,12 @@ from .record import (
     UnknownAntennaPattern,
     EulerAngles,
     BeamAntennaPattern,
+    GenericRadio,
+    SimpleIntercomRadio,
+    BasicHaveQuickMP,
+    VariableTransmitterParametersRecord,
+    HighFidelityHAVEQUICKRadio,
+    UnknownVariableTransmitterParameters,
 )
 from .stream import DataInputStream, DataOutputStream
 from .types import (
@@ -853,36 +859,6 @@ class AttachedParts:
         self.partAttachedTo = inputStream.read_unsigned_short()
         self.parameterType = inputStream.read_unsigned_int()
         self.parameterValue = inputStream.read_long()
-
-
-class VariableTransmitterParameters:
-    """Section 6.2.94
-    
-    Relates to radios. NOT COMPLETE.
-    """
-
-    def __init__(self, recordType: enum32 = 0, data: bytes = b""):
-        self.recordType = recordType  # [UID 66]  Variable Parameter Record Type
-        self.data = data
-    
-    def marshalledSize(self) -> int:
-        return 6 + len(self.data)
-    
-    @property
-    def recordLength(self) -> uint16:
-        return self.marshalledSize()
-
-    def serialize(self, outputStream: DataOutputStream) -> None:
-        """serialize the class"""
-        outputStream.write_uint32(self.recordType)
-        outputStream.write_uint16(self.recordLength)
-        outputStream.write_bytes(self.data)
-
-    def parse(self, inputStream: DataInputStream) -> None:
-        """Parse a message. This may recursively call embedded objects."""
-        self.recordType = inputStream.read_uint32()
-        recordLength = inputStream.read_uint16()
-        self.data = inputStream.read_bytes(recordLength)
 
 
 class Attribute:
@@ -5353,7 +5329,7 @@ class TransmitterPdu(RadioCommunicationsFamilyPdu):
                  cryptoKeyId: struct16 = 0,  # See Table 175
                  modulationParameters: ModulationParametersRecord | None = None,
                  antennaPattern: AntennaPatternRecord | None = None,
-                 variableTransmitterParameters: Sequence[VariableTransmitterParameters] | None = None):
+                 variableTransmitterParameters: Sequence[VariableTransmitterParametersRecord] | None = None):
         super(TransmitterPdu, self).__init__()
         self.radioReferenceID = radioReferenceID or EntityID()
         """ID of the entity that is the source of the communication"""

--- a/opendis/dis7.py
+++ b/opendis/dis7.py
@@ -15,6 +15,7 @@ from .record import (
     GenericRadio,
     SimpleIntercomRadio,
     BasicHaveQuickMP,
+    CCTTSincgarsMP,
     VariableTransmitterParametersRecord,
     HighFidelityHAVEQUICKRadio,
     UnknownVariableTransmitterParameters,

--- a/opendis/dis7.py
+++ b/opendis/dis7.py
@@ -5353,7 +5353,11 @@ class TransmitterPdu(RadioCommunicationsFamilyPdu):
         self.padding3 = 0
         self.modulationParameters = modulationParameters
         self.antennaPattern = antennaPattern
-        self.variableTransmitterParameters = variableTransmitterParameters or []
+        self.variableTransmitterParameters = (
+            list(variableTransmitterParameters)
+            if variableTransmitterParameters
+            else []
+        )
 
     @property
     def antennaPatternLength(self) -> uint16:

--- a/opendis/dis7.py
+++ b/opendis/dis7.py
@@ -5467,15 +5467,19 @@ class TransmitterPdu(RadioCommunicationsFamilyPdu):
 
         ## Antenna Pattern
         if antennaPatternLength > 0:
-            self.antennaPattern = UnknownAntennaPattern()
-            self.antennaPattern.parse(
-                inputStream,
-                bytelength=antennaPatternLength
-            )
+            if self.antennaPatternType == 1:
+                self.antennaPattern = BeamAntennaPattern()
+                self.antennaPattern.parse(inputStream)
+            else:
+                self.antennaPattern = UnknownAntennaPattern()
+                self.antennaPattern.parse(
+                    inputStream,
+                    bytelength=antennaPatternLength
+                )
         else:
             self.antennaPattern = None
-
-
+        
+        ## TODO: Variable Transmitter Parameters
 
 
 class ElectromagneticEmissionsPdu(DistributedEmissionsFamilyPdu):

--- a/opendis/record.py
+++ b/opendis/record.py
@@ -452,13 +452,11 @@ class UnknownVariableTransmitterParameters(VariableTransmitterParametersRecord):
         return self.marshalledSize()
 
     def serialize(self, outputStream: DataOutputStream) -> None:
-        """serialize the class"""
         outputStream.write_uint32(self.recordType)
         outputStream.write_uint16(self.recordLength)
         outputStream.write_bytes(self.data)
 
     def parse(self, inputStream: DataInputStream) -> None:
-        """Parse a message. This may recursively call embedded objects."""
         self.recordType = inputStream.read_uint32()
         recordLength = inputStream.read_uint16()
         self.data = inputStream.read_bytes(recordLength)

--- a/opendis/record.py
+++ b/opendis/record.py
@@ -309,6 +309,50 @@ class BasicHaveQuickMP(ModulationParametersRecord):
         self.padding = inputStream.read_uint32()
 
 
+class CCTTSincgarsMP(ModulationParametersRecord):
+    """Annex C 6.2.3, Table C.7 — CCTT SINCGARS MP record"""
+
+    def __init__(self,
+                 fh_net_id: uint16 = 0,
+                 hop_set_id: uint16 = 0,
+                 lockout_set_id: uint16 = 0,
+                 start_of_message: enum8 = 0,
+                 clear_channel: enum8 = 0,
+                 fh_sync_time_offset: uint32 = 0,
+                 transmission_security_key: uint16 = 0):
+        self.fh_net_id = fh_net_id
+        self.hop_set_id = hop_set_id
+        self.lockout_set_id = lockout_set_id
+        self.start_of_message = start_of_message
+        self.clear_channel = clear_channel
+        self.fh_sync_time_offset = fh_sync_time_offset
+        self.transmission_security_key = transmission_security_key
+        self.padding: uint16 = 0
+
+    def marshalledSize(self) -> int:
+        return 16  # bytes
+
+    def serialize(self, outputStream: DataOutputStream) -> None:
+        outputStream.write_uint16(self.fh_net_id)
+        outputStream.write_uint16(self.hop_set_id)
+        outputStream.write_uint16(self.lockout_set_id)
+        outputStream.write_uint8(self.start_of_message)
+        outputStream.write_uint8(self.clear_channel)
+        outputStream.write_uint32(self.fh_sync_time_offset)
+        outputStream.write_uint16(self.transmission_security_key)
+        outputStream.write_uint16(self.padding)
+
+    def parse(self, inputStream: DataInputStream) -> None:
+        self.fh_net_id = inputStream.read_uint16()
+        self.hop_set_id = inputStream.read_uint16()
+        self.lockout_set_id = inputStream.read_uint16()
+        self.start_of_message = inputStream.read_uint8()
+        self.clear_channel = inputStream.read_uint8()
+        self.fh_sync_time_offset = inputStream.read_uint32()
+        self.transmission_security_key = inputStream.read_uint16()
+        self.padding = inputStream.read_uint16()
+
+
 class AntennaPatternRecord(ABC):
     """6.2.8 Antenna Pattern record
     

--- a/opendis/record.py
+++ b/opendis/record.py
@@ -3,7 +3,7 @@
 This module defines classes for various record types used in DIS PDUs.
 """
 
-from abc import abstractmethod
+from abc import ABC, abstractmethod
 
 import bitfield
 from .stream import DataInputStream, DataOutputStream
@@ -153,7 +153,7 @@ class SpreadSpectrum:
         self.timeHopping = bool(record_bitfield.timeHopping)
 
 
-class ModulationParametersRecord:
+class ModulationParametersRecord(ABC):
     """Base class for modulation parameters records, as defined in Annex C."""
 
     @abstractmethod
@@ -269,7 +269,7 @@ class BasicHaveQuickMP(ModulationParametersRecord):
         self.padding = inputStream.read_uint32()
 
 
-class AntennaPatternRecord:
+class AntennaPatternRecord(ABC):
     """Section 6.2.8
     
     The total length of each record shall be a multiple of 64 bits.

--- a/opendis/record.py
+++ b/opendis/record.py
@@ -8,14 +8,49 @@ from abc import ABC, abstractmethod
 import bitfield
 from .stream import DataInputStream, DataOutputStream
 from .types import (
+    enum8,
     enum16,
     bf_enum,
     bf_int,
     bf_uint,
+    float32,
     uint8,
     uint16,
     uint32,
 )
+
+
+class EulerAngles:
+    """Section 6.2.32 Euler Angles record
+
+    Three floating point values representing an orientation, psi, theta,
+    and phi, aka the euler angles, in radians.
+    These angles shall be specified with respect to the entity's coordinate
+    system.
+    """
+
+    def __init__(self,
+                 psi: float32 = 0.0,
+                 theta: float32 = 0.0,
+                 phi: float32 = 0.0):  # in radians
+        self.psi = psi
+        self.theta = theta
+        self.phi = phi
+
+    def marshalledSize(self) -> int:
+        return 12
+
+    def serialize(self, outputStream):
+        """serialize the class"""
+        outputStream.write_float32(self.psi)
+        outputStream.write_float32(self.theta)
+        outputStream.write_float32(self.phi)
+
+    def parse(self, inputStream):
+        """Parse a message. This may recursively call embedded objects."""
+        self.psi = inputStream.read_float32()
+        self.theta = inputStream.read_float32()
+        self.phi = inputStream.read_float32()
 
 
 class ModulationType:
@@ -310,3 +345,61 @@ class UnknownAntennaPattern(AntennaPatternRecord):
     def parse(self, inputStream: DataInputStream, bytelength: int = 0) -> None:
         """Parse a message. This may recursively call embedded objects."""
         self.data = inputStream.read_bytes(bytelength)
+
+
+class BeamAntennaPattern(AntennaPatternRecord):
+    """6.2.8.2 Beam Antenna Pattern record
+    
+    Used when the antenna pattern type field has a value of 1. Specifies the
+    direction, pattern, and polarization of radiation from an antenna.
+    """
+
+    def __init__(self,
+                 beamDirection: "EulerAngles | None" = None,
+                 azimuthBeamwidth: float32 = 0.0,  # in radians
+                 elevationBeamwidth: float32 = 0.0,  # in radians
+                 referenceSystem: enum8 = 0,  # [UID 168]
+                 ez: float32 = 0.0,
+                 ex: float32 = 0.0,
+                 phase: float32 = 0.0):  # in radians
+        self.beamDirection = beamDirection or EulerAngles()
+        """The rotation that transforms the reference coordinate sytem into the beam coordinate system. Either world coordinates or entity coordinates may be used as the reference coordinate system, as specified by the reference system field of the antenna pattern record."""
+        self.azimuthBeamwidth = azimuthBeamwidth
+        self.elevationBeamwidth = elevationBeamwidth
+        self.referenceSystem = referenceSystem
+        self.padding1: uint8 = 0
+        self.padding2: uint16 = 0
+        self.ez = ez
+        """This field shall specify the magnitude of the Z-component (in beam coordinates) of the Electrical field at some arbitrary single point in the main beam and in the far field of the antenna."""
+        self.ex = ex
+        """This field shall specify the magnitude of the X-component (in beam coordinates) of the Electrical field at some arbitrary single point in the main beam and in the far field of the antenna."""
+        self.phase = phase
+        """This field shall specify the phase angle between EZ and EX in radians. If fully omni-directional antenna is modeled using beam pattern type one, the omni-directional antenna shall be represented by beam direction Euler angles psi, theta, and phi of zero, an azimuth beamwidth of 2PI, and an elevation beamwidth of PI"""
+        self.padding3: uint32 = 0
+
+    def marshalledSize(self) -> int:
+        return 40
+
+    def serialize(self, outputStream: DataOutputStream) -> None:
+        self.beamDirection.serialize(outputStream)
+        outputStream.write_float32(self.azimuthBeamwidth)
+        outputStream.write_float32(self.elevationBeamwidth)
+        outputStream.write_uint8(self.referenceSystem)
+        outputStream.write_uint8(self.padding1)
+        outputStream.write_uint16(self.padding2)
+        outputStream.write_float32(self.ez)
+        outputStream.write_float32(self.ex)
+        outputStream.write_float32(self.phase)
+        outputStream.write_uint32(self.padding3)
+
+    def parse(self, inputStream: DataInputStream) -> None:
+        self.beamDirection.parse(inputStream)
+        self.azimuthBeamwidth = inputStream.read_float32()
+        self.elevationBeamwidth = inputStream.read_float32()
+        self.referenceSystem = inputStream.read_uint8()
+        self.padding1 = inputStream.read_uint8()
+        self.padding2 = inputStream.read_uint16()
+        self.ez = inputStream.read_float32()
+        self.ex = inputStream.read_float32()
+        self.phase = inputStream.read_float32()
+        self.padding3 = inputStream.read_uint32()

--- a/opendis/record.py
+++ b/opendis/record.py
@@ -269,40 +269,6 @@ class BasicHaveQuickMP(ModulationParametersRecord):
         self.padding = inputStream.read_uint32()
 
 
-class ModulationParameters:
-    """Section 6.2.58
-
-    Modulation parameters associated with a specific radio system.
-
-    This class is not designed to be instantiated directly with no arguments.
-    """
-
-    def __init__(self,
-                 # record must be provided as there is no default value.
-                 record: ModulationParametersRecord):
-        self.record = record
-        # ModulationParameters requires padding to 64-bit (8-byte) boundary
-        self.padding = 8 - (self.record.marshalledSize() % 8) % 8
-
-    def marshalledSize(self) -> int:
-        return self.record.marshalledSize() + self.padding
-
-    def serialize(self, outputStream: DataOutputStream) -> None:
-        self.record.serialize(outputStream)
-        outputStream.write_bytes(b'\x00' * self.padding)
-
-    def parse(self, inputStream: DataInputStream) -> None:
-        self.record.parse(inputStream)
-        bytes_to_read = 8 - (self.record.marshalledSize() % 8) % 8
-        if bytes_to_read > 0:
-            self.padding = int.from_bytes(
-                inputStream.read_bytes(bytes_to_read),
-                byteorder='big'
-            )
-        else:
-            self.padding = 0
-
-
 class AntennaPatternRecord:
     """Section 6.2.8
     

--- a/opendis/record.py
+++ b/opendis/record.py
@@ -5,7 +5,7 @@ This module defines classes for various record types used in DIS PDUs.
 
 from abc import ABC, abstractmethod
 
-import bitfield
+from . import bitfield
 from .stream import DataInputStream, DataOutputStream
 from .types import (
     enum8,

--- a/opendis/record.py
+++ b/opendis/record.py
@@ -154,7 +154,11 @@ class SpreadSpectrum:
 
 
 class ModulationParametersRecord(ABC):
-    """Base class for modulation parameters records, as defined in Annex C."""
+    """6.2.58 Modulation Parameters record
+    
+    Base class for modulation parameters records, as defined in Annex C.
+    The total length of each record shall be a multiple of 64 bits.
+    """
 
     @abstractmethod
     def marshalledSize(self) -> int:
@@ -270,7 +274,7 @@ class BasicHaveQuickMP(ModulationParametersRecord):
 
 
 class AntennaPatternRecord(ABC):
-    """Section 6.2.8
+    """6.2.8 Antenna Pattern record
     
     The total length of each record shall be a multiple of 64 bits.
     """

--- a/opendis/record/__init__.py
+++ b/opendis/record/__init__.py
@@ -6,8 +6,8 @@ This module defines classes for various record types used in DIS PDUs.
 from abc import ABC, abstractmethod
 
 from . import bitfield
-from .stream import DataInputStream, DataOutputStream
-from .types import (
+from ..stream import DataInputStream, DataOutputStream
+from ..types import (
     enum8,
     enum16,
     enum32,

--- a/opendis/record/bitfield.py
+++ b/opendis/record/bitfield.py
@@ -17,6 +17,7 @@ from ctypes import (
 from typing import Literal, Sequence
 
 from opendis.stream import DataInputStream, DataOutputStream
+from opendis.types import bf_enum, bf_int, bf_uint
 
 # Type definitions for bitfield field descriptors
 CTypeFieldDescription = tuple[str, type[_SimpleCData], int]


### PR DESCRIPTION
This PR implements:

- Parsing of modulation parameters for Generic Radio, Simple Intercom Radio, HAVE QUICK radio, CCTT SINCGARS radio from Annex C
- Parsing of variable transmitter parameters for HAVE QUICK radio (high fidelity)
- Parsing of Beam Antenna pattern
- fallback to Unknown record types for the above

QoL improvements:
- `bitfield` moved to its own module under the `record` namespace